### PR TITLE
[SELS-TASK] Admin-Delete Words and Choices [BE]

### DIFF
--- a/backend/app/Http/Controllers/WordChoiceController.php
+++ b/backend/app/Http/Controllers/WordChoiceController.php
@@ -76,4 +76,18 @@ class WordChoiceController extends Controller
             'errors' => null
         ],200);
     }
+    public function destroy($lessonID, $wordID)
+    {
+        Choice::where('word_question_id',$wordID)->delete();
+        $word=WordQuestion::where('id',$wordID)->delete();
+        if(!$word){
+            return response()->json(['status' => false, 'data'=>null, 'message' => 'Cannot delete word.', 'errors' => 'Delete Error'], 500);
+        }
+        return response()->json([
+            'status' => true,
+            'data'=>$word, 
+            'message' => 'Word and choices successfully deleted.', 
+            'errors' => null
+        ],200);
+    }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -31,4 +31,5 @@ Route::middleware(['auth:sanctum','admin'])->group(function () {
   Route::post('/lessons/{id}/words',[WordChoiceController::class, 'store']);
   Route::get('/lessons/{lessonID}/words/{wordID}',[WordChoiceController::class, 'show']);
   Route::put('/lessons/{lessonID}/words/{wordID}',[WordChoiceController::class, 'update']);
+  Route::delete('/lessons/{lessonID}/words/{wordID}',[WordChoiceController::class, 'destroy']);
 });

--- a/frontend/src/pages/AdminWordsChoicesPage.js
+++ b/frontend/src/pages/AdminWordsChoicesPage.js
@@ -1,7 +1,11 @@
 import React, { useState } from "react";
 import DataTable from "react-data-table-component";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { useGetWordsChoicesQuery } from "../store/wordsChoicesSlice";
+import { toast } from "react-toastify";
+import {
+  useDeleteWordChoiceMutation,
+  useGetWordsChoicesQuery,
+} from "../store/wordsChoicesSlice";
 import withAdminProtection from "../utilities/withAdminProtection";
 import Button from "./components/button/Button";
 import { customStyles } from "./components/datatable/datatable";
@@ -15,17 +19,31 @@ const AdminWordsChoicesPage = () => {
   const { lessonID } = useParams();
   const [show, setShow] = useState(false);
   const [rowID, setRowID] = useState(-1);
-  const handleDeleteButton = (id) => {
-    setRowID(id);
-    setShow(true);
-  };
-  const handleDeleteModal = async () => {};
+  const [deleteWordChoice, { isLoading: deleteWordLoading }] =
+    useDeleteWordChoiceMutation();
   const {
     data: lesson,
     isLoading,
     isError,
     isSuccess,
   } = useGetWordsChoicesQuery(lessonID);
+  const handleDeleteButton = (id) => {
+    setRowID(id);
+    setShow(true);
+  };
+  const handleDeleteModal = async () => {
+    try {
+      const res = await deleteWordChoice({ lessonID, wordID: rowID }).unwrap();
+      toast.success(res.message);
+      setShow(false);
+    } catch (error) {
+      if (error && error.status === 500) {
+        toast.error(error.message);
+      } else {
+        toast.error(error);
+      }
+    }
+  };
   const columns = [
     {
       name: "Word",
@@ -116,6 +134,7 @@ const AdminWordsChoicesPage = () => {
           setShow={setShow}
           closeLabel={"Close"}
           actionLabel={"Delete Word"}
+          isLoading={deleteWordLoading}
           handleModalClick={handleDeleteModal}
         />
       </>

--- a/frontend/src/store/wordsChoicesSlice.js
+++ b/frontend/src/store/wordsChoicesSlice.js
@@ -36,6 +36,15 @@ export const extendedApiSlice = apiSlice.injectEndpoints({
         { type: "WordChoice", id: arg.id },
       ],
     }),
+    deleteWordChoice: builder.mutation({
+      query: ({ lessonID, wordID }) => ({
+        url: `/lessons/${lessonID}/words/${wordID}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: (result, error, arg) => [
+        { type: "WordChoice", id: arg.id },
+      ],
+    }),
   }),
 });
 
@@ -44,4 +53,5 @@ export const {
   useGetWordChoiceQuery,
   useCreateWordChoiceMutation,
   useUpdateWordChoiceMutation,
+  useDeleteWordChoiceMutation,
 } = extendedApiSlice;


### PR DESCRIPTION
**[Asana Link]**
https://app.asana.com/0/1202837324865076/1202837642887528/f

**[Commands]**  
cd backend
php artisan serve  
cd frontend
npm start 
login one admin account from the seeded records (password is **password** for all accounts)
click the view words button of any lessons
click Delete button on any word record

**[Pre-conditions]** 
None

**[Expected Output]** 
Should be able to delete a word and associated choices
Delete action button on modal should now workl
Shows status message if deletion is successful or not

**[Notes]**  
Frontend/UI integration

**[Screenshots]**  
![image](https://user-images.githubusercontent.com/110364637/188321244-037b17d8-3bec-446a-a6ac-684230eab4db.png)
![image](https://user-images.githubusercontent.com/110364637/188321262-e19661cc-f45e-4fa6-ae40-4409e001f0ff.png)
